### PR TITLE
Streamline group label

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -16,6 +16,11 @@ app_server <- function( input, output, session ){
 
   downloaded_sites <- rcoleo::download_sites_sf()
   
+  # add a display name column
+  
+  downloaded_sites_names <- add_site_name_df(downloaded_sites)
+  
+  
   got_clicked_site <- mod_map_select_server("sitemap",
                                             what_to_click = "marker", 
                                             fun = plot_rcoleo_sites,

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -22,6 +22,8 @@ app_server <- function( input, output, session ){
   
   # make lookup vecs
   site_code_lookup <- make_lookup_vector(downloaded_sites_names, "site_code", "display_name")
+  cell_name_lookup <- make_lookup_vector(downloaded_sites, 
+                                         value_col = "cell.name", name_col = "cell_id")
   
   got_clicked_site <- mod_map_select_server("sitemap",
                                             what_to_click = "marker", 
@@ -43,7 +45,7 @@ app_server <- function( input, output, session ){
   
   mod_environment_display_server("siteenv",
                                  sites = downloaded_sites_names,
-                                 region = got_clicked_site
+                                 region = got_clicked_site, lookup_vec = cell_name_lookup
                                  )
   
   

--- a/R/make_site_name.R
+++ b/R/make_site_name.R
@@ -2,21 +2,34 @@
 
 # take a clicked name and spit out the site name
 
-make_site_name <- function(got_clicked_site_val, cell_data){
+make_site_name <- function(got_clicked_site_val, cell_lookup_vec){
   
   req(got_clicked_site_val)
-  # is.reactive(got_clicked_site)
+  
+  good_name <- cell_lookup_vec[[got_clicked_site_val]]
+  
+  return(good_name)
+}
+
+
+add_site_name_df <- function(cell_data){
   
   stopifnot(any(c("type", "cell.name") %in% names(cell_data)))
   
-  click_info <- subset(cell_data, site_code == got_clicked_site_val)
+  outdata <- transform(cell_data, display_name = paste0(cell.name," -- ", type))
+
+  return(outdata)
+}
+
+
+make_lookup_vector <- function(some_df, col1, col2){
+  # check for error
+  stopifnot(any(c(col1, col2) %in% names(some_df)))
   
-  stopifnot(nrow(click_info) == 1)
+  names_df <- as.data.frame(some_df)[,c(col1, col2)]
   
-  cellname <- click_info$cell.name
-  habitat <-  click_info$type
+  dedup_names <- names_df[!duplicated(names_df), ]
   
-  good_name <- paste0(cellname," -- ", habitat)
-  
-  return(good_name)
+  xx <- setNames(dedup_names[[col1]], dedup_names[[col2]])
+  return(xx)
 }

--- a/R/make_site_name.R
+++ b/R/make_site_name.R
@@ -4,8 +4,6 @@
 
 make_site_name <- function(got_clicked_site_val, cell_lookup_vec){
   
-  req(got_clicked_site_val)
-  
   good_name <- cell_lookup_vec[[got_clicked_site_val]]
   
   return(good_name)
@@ -22,14 +20,14 @@ add_site_name_df <- function(cell_data){
 }
 
 
-make_lookup_vector <- function(some_df, col1, col2){
+make_lookup_vector <- function(some_df, value_col, name_col){
   # check for error
-  stopifnot(any(c(col1, col2) %in% names(some_df)))
+  stopifnot(any(c(value_col, name_col) %in% names(some_df)))
   
-  names_df <- as.data.frame(some_df)[,c(col1, col2)]
+  names_df <- as.data.frame(some_df)[,c(value_col, name_col)]
   
   dedup_names <- names_df[!duplicated(names_df), ]
   
-  xx <- setNames(dedup_names[[col1]], dedup_names[[col2]])
+  xx <- setNames(dedup_names[[value_col]], dedup_names[[name_col]])
   return(xx)
 }

--- a/R/mod_environment_display.R
+++ b/R/mod_environment_display.R
@@ -22,14 +22,14 @@ mod_environment_display_ui <- function(id){
 #' environment_display Server Functions
 #'
 #' @noRd 
-mod_environment_display_server <- function(id, sites, region){
+mod_environment_display_server <- function(id, sites, region,  lookup_vec){
   assertthat::assert_that(shiny::is.reactive(region))
   
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     
     plot_to_show <- reactive(
-      plot_one_site(site_clicked = region(), site_df = sites)
+      plot_one_site(site_clicked = region(), site_df = sites,  lookup_vec = lookup_vec)
     )
     
     output$blurb = renderText("Les différents sites de surveillance du MFFP connaissent des précipitations et des températures différentes. 
@@ -66,8 +66,14 @@ env_ui <- function(request) {
 env_server <- function(input, output, session) {
   
   downloaded_sites <- rcoleo::download_sites_sf()
+  downloaded_sites_names <- add_site_name_df(downloaded_sites)
   
-  mod_environment_display_server("environment_display_ui_1", sites = downloaded_sites, region = reactive("123_89_L01"))
+  cell_name_lookup <- make_lookup_vector(downloaded_sites, 
+                                         value_col = "cell.name", name_col = "cell_id")
+  
+  mod_environment_display_server("environment_display_ui_1",
+                                 sites = downloaded_sites_names, 
+                                 region = reactive("Mékinac (B) -- marais"), lookup_vec = cell_name_lookup)
 }
 
 

--- a/R/utils_temp_precip_plot.R
+++ b/R/utils_temp_precip_plot.R
@@ -7,7 +7,7 @@
 #' @return
 #' @export
 #'
-plot_site_env <- function(type, site){
+plot_site_env <- function(type, site, lookup_vec){
   if (!(type %in% c("precip", "temp"))) stop("type must be either precip or temp")
   
   dat <- switch(type,
@@ -33,7 +33,7 @@ plot_site_env <- function(type, site){
   
   lightplot <- 
     ggplot2::ggplot(dat) + 
-    ggplot2::aes(x = Month, y = yvar, group = nn, tooltip = as.character(nn)) + 
+    ggplot2::aes(x = Month, y = yvar, group = nn, tooltip = lookup_vec[as.character(nn)]) + 
     ggiraph::geom_polygon_interactive(fill = NA, col = lightcol) +
     ggplot2::coord_polar(start = -pi * 1/12) + 
     ggplot2::theme_minimal() + 
@@ -57,12 +57,12 @@ plot_site_env <- function(type, site){
 #' @export
 #'
 #' @import patchwork
-plot_one_site <- function(site_clicked, site_df){
+plot_one_site <- function(site_clicked, site_df, lookup_vec){
   stopifnot(is.data.frame(site_df))
   
   cell <- site_df[["cell_id"]][which(site_df[["display_name"]] == site_clicked)]
-  p_precip <- plot_site_env("precip", cell)
-  p_temper <- plot_site_env("temp", cell)
+  p_precip <- plot_site_env("precip", cell, lookup_vec = lookup_vec)
+  p_temper <- plot_site_env("temp", cell, lookup_vec = lookup_vec)
   
   plot_list <- list(precip = ggiraph::girafe(code = print(p_precip)),
        temper = ggiraph::girafe(code = print(p_temper)))

--- a/R/utils_temp_precip_plot.R
+++ b/R/utils_temp_precip_plot.R
@@ -60,7 +60,7 @@ plot_site_env <- function(type, site){
 plot_one_site <- function(site_clicked, site_df){
   stopifnot(is.data.frame(site_df))
   
-  cell <- site_df[["cell_id"]][which(site_df[["site_code"]] == site_clicked)]
+  cell <- site_df[["cell_id"]][which(site_df[["display_name"]] == site_clicked)]
   p_precip <- plot_site_env("precip", cell)
   p_temper <- plot_site_env("temp", cell)
   

--- a/man/plot_one_site.Rd
+++ b/man/plot_one_site.Rd
@@ -4,7 +4,7 @@
 \alias{plot_one_site}
 \title{Plot one site}
 \usage{
-plot_one_site(site_clicked, site_df)
+plot_one_site(site_clicked, site_df, lookup_vec)
 }
 \arguments{
 \item{site_clicked}{the site_id returned by clicking the map}

--- a/man/plot_site_env.Rd
+++ b/man/plot_site_env.Rd
@@ -4,7 +4,7 @@
 \alias{plot_site_env}
 \title{Plot environmental  variables at at site}
 \usage{
-plot_site_env(type, site)
+plot_site_env(type, site, lookup_vec)
 }
 \arguments{
 \item{type}{type of environment. one of "precip" or "temp"}


### PR DESCRIPTION
tooltip in model popup has the cell name

lots of bookkeeping to work with the "display_name", converting it to either cell names or site codes as other funcitons demand